### PR TITLE
Update bignumber.js dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   },
   "dependencies": {
     "@parity/ledger": "2.1.x",
+    "bignumber.js": "4.1.0",
     "eventemitter3": "^2.0.3",
     "loglevel": "1.4.1",
     "mobx": "2.6.4",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "makeshift": "^1.1.0"
   },
   "dependencies": {
-    "@parity/ledger": "2.1.x",
+    "@parity/ledger": "~2.1.3",
     "bignumber.js": "4.1.0",
     "eventemitter3": "^2.0.3",
     "loglevel": "1.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -961,6 +961,10 @@ bignumber.js@3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-3.0.1.tgz#807652d10e39de37e9e3497247edc798bb746f76"
 
+bignumber.js@4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-4.1.0.tgz#db6f14067c140bd46624815a7916c92d9b6c24b1"
+
 binary-extensions@^1.0.0:
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.11.0.tgz#46aa1751fb6a2f93ee5e689bb1087d4b14c6c205"

--- a/yarn.lock
+++ b/yarn.lock
@@ -54,11 +54,11 @@
     lodash "^4.2.0"
     to-fast-properties "^2.0.0"
 
-"@parity/ledger@2.1.x":
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/@parity/ledger/-/ledger-2.1.2.tgz#d7f27b5c6084cda8dc38e1333454a67c752496a0"
+"@parity/ledger@~2.1.3":
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/@parity/ledger/-/ledger-2.1.3.tgz#e5eb67eac6ed8a7181b45cf49d3cc4a140b1a667"
   dependencies:
-    bignumber.js "3.0.1"
+    bignumber.js "4.1.0"
     ethereumjs-tx "^1.2.5"
     u2f-api "0.0.9"
     u2f-api-polyfill "0.4.3"
@@ -956,10 +956,6 @@ bcrypt-pbkdf@^1.0.0:
   resolved "https://registry.yarnpkg.com/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz#63bc5dcb61331b92bc05fd528953c33462a06f8d"
   dependencies:
     tweetnacl "^0.14.3"
-
-bignumber.js@3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-3.0.1.tgz#807652d10e39de37e9e3497247edc798bb746f76"
 
 bignumber.js@4.1.0:
   version "4.1.0"


### PR DESCRIPTION
* Add missing bignumber.js dependency to package.json
* Update to 3.1.0+ (4.1.0 to mirror `@parity/ui`) to allow verifying across repos if a value is an instance of BigNumber using `.isBigNumber` rather than `instanceof` : https://github.com/MikeMcl/bignumber.js/issues/111